### PR TITLE
Use packaged wpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,6 @@
             "homepage": "https://mirekdlugosz.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/WordPress/WordPress-Coding-Standards"
-        }
-    ],
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -22,7 +16,7 @@
         "archive-format": "zip"
     },
     "require-dev": {
-        "wp-coding-standards/wpcs": "dev-develop",
+        "wp-coding-standards/wpcs": "^3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "phpcompatibility/phpcompatibility-wp": "^2.1"
     },


### PR DESCRIPTION
The latest currently available version of [WordPress-Coding-Standards](https://github.com/WordPress/WordPress-Coding-Standards) is 2.3.0, released in May 2020.

That version is not compatible with PHP 8.0. The compatibility was fixed in https://github.com/WordPress/WordPress-Coding-Standards/commit/7cd46bed1e6a7a2af3fe24c7f4a044da3076d8f4 just few months later.

As of January 2023, there is no version of PHP 7.x maintained upstream.

I am not interested in developing against unsupported version of PHP. On the other hand, there is no packaged version of WPCS I could use in PHP 8 environment.

As a temporary solution, I switched WPCS to git version. But we should switch back to packaged version as soon as there is PHP 8-compatible package available.

This PR contains changes that are assumed to be sufficient for the switch. But we will need to verify once WPCS releases new version.